### PR TITLE
問19：日曜日の数え上げ

### DIFF
--- a/no019/problem.rb
+++ b/no019/problem.rb
@@ -1,5 +1,5 @@
 require 'date'
 
 def count_sunday(start_year, start_month, end_year, end_month)
-  Date.new(start_year, start_month).upto(Date.new(end_year, end_month)).select { |day| day.mday == 1 }.count
+  Date.new(start_year, start_month).upto(Date.new(end_year, end_month)).select { |day| day.mday == 1 && day.wday.zero? }.count
 end

--- a/no019/problem.rb
+++ b/no019/problem.rb
@@ -1,5 +1,5 @@
 require 'date'
 
 def count_sunday(start_year, start_month, end_year, end_month)
-  Date.new(start_year, start_month).upto(Date.new(end_year, end_month)).count
+  Date.new(start_year, start_month).upto(Date.new(end_year, end_month)).select { |day| day.mday == 1 }.count
 end

--- a/no019/problem.rb
+++ b/no019/problem.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 def count_sunday(start_year, start_month, end_year, end_month)
-  0
+  Date.new(start_year, start_month).upto(Date.new(end_year, end_month)).count
 end

--- a/no019/problem.rb
+++ b/no019/problem.rb
@@ -3,3 +3,5 @@ require 'date'
 def count_sunday(start_year, start_month, end_year, end_month)
   Date.new(start_year, start_month).upto(Date.new(end_year, end_month)).select { |day| day.mday == 1 && day.wday.zero? }.count
 end
+
+puts count_sunday(1901, 1, 2000, 12)

--- a/no019/problem.rb
+++ b/no019/problem.rb
@@ -1,0 +1,3 @@
+def count_sunday(start_year, start_month, end_year, end_month)
+  0
+end

--- a/no019/problem_test.rb
+++ b/no019/problem_test.rb
@@ -1,0 +1,11 @@
+require 'minitest/autorun'
+require './problem'
+
+require 'minitest/reporters'
+Minitest::Reporters.use!
+
+class ProblemTest < Minitest::Test
+  def test_path_array
+    assert_equal 0, count_sunday(1900, 1, 1900, 1)
+  end
+end

--- a/no019/problem_test.rb
+++ b/no019/problem_test.rb
@@ -7,6 +7,6 @@ Minitest::Reporters.use!
 class ProblemTest < Minitest::Test
   def test_path_array
     assert_equal 1, count_sunday(1900, 1, 1900, 1)
-    assert_equal 335, count_sunday(1900, 1, 1900, 12)
+    assert_equal 12, count_sunday(1900, 1, 1900, 12)
   end
 end

--- a/no019/problem_test.rb
+++ b/no019/problem_test.rb
@@ -6,6 +6,7 @@ Minitest::Reporters.use!
 
 class ProblemTest < Minitest::Test
   def test_path_array
-    assert_equal 0, count_sunday(1900, 1, 1900, 1)
+    assert_equal 1, count_sunday(1900, 1, 1900, 1)
+    assert_equal 335, count_sunday(1900, 1, 1900, 12)
   end
 end

--- a/no019/problem_test.rb
+++ b/no019/problem_test.rb
@@ -6,7 +6,7 @@ Minitest::Reporters.use!
 
 class ProblemTest < Minitest::Test
   def test_path_array
-    assert_equal 1, count_sunday(1900, 1, 1900, 1)
-    assert_equal 12, count_sunday(1900, 1, 1900, 12)
+    assert_equal 0, count_sunday(1900, 1, 1900, 1)
+    assert_equal 2, count_sunday(2018, 1, 2018, 12)
   end
 end


### PR DESCRIPTION
問題文
---
You are given the following information, but you may prefer to do some research for yourself.

1 Jan 1900 was a Monday.
Thirty days has September,
April, June and November.
All the rest have thirty-one,
Saving February alone,
Which has twenty-eight, rain or shine.
And on leap years, twenty-nine.
A leap year occurs on any year evenly divisible by 4, but not on a century unless it is divisible by 400.
How many Sundays fell on the first of the month during the twentieth century (1 Jan 1901 to 31 Dec 2000)?

---

次の情報が与えられている.

1900年1月1日は月曜日である.
9月, 4月, 6月, 11月は30日まであり, 2月を除く他の月は31日まである.
2月は28日まであるが, うるう年のときは29日である.
うるう年は西暦が4で割り切れる年に起こる. しかし, 西暦が400で割り切れず100で割り切れる年はうるう年でない.
20世紀(1901年1月1日から2000年12月31日)中に月の初めが日曜日になるのは何回あるか?

その他
---
- うるう年云々はDateライブラリを利用してよしなにしてもらった