### PR TITLE
問23：非過剰数和

### DIFF
--- a/no023/problem.rb
+++ b/no023/problem.rb
@@ -16,3 +16,19 @@ class Integer
     sum_of_proper_divisors > self
   end
 end
+
+def answer(from, to)
+  abundants = (from..to).select(&:abundant?)
+
+  sum_of_two_abundants = []
+  abundants.each_with_index do |n, i|
+    abundants[i..abundants.length].each do |other|
+      sum_of_two_abundants << n + other
+    end
+  end
+
+  sum_of_two_abundants.uniq!
+
+  (from..to).reject { |n| sum_of_two_abundants.include?(n) }.inject(:+)
+end
+puts answer(1, 28_123)

--- a/no023/problem.rb
+++ b/no023/problem.rb
@@ -1,0 +1,18 @@
+require 'prime'
+
+class Integer
+  def sum_of_proper_divisors
+    if self != 1
+      sum_of_divisors = Prime.prime_division(self).map do |n, i|
+        (n**(i + 1) - 1) / (n - 1)
+      end
+      sum_of_divisors.inject(:*) - self
+    else
+      1
+    end
+  end
+
+  def abundant?
+    sum_of_proper_divisors > self
+  end
+end

--- a/no023/problem_test.rb
+++ b/no023/problem_test.rb
@@ -1,0 +1,15 @@
+require 'minitest/autorun'
+require './problem'
+
+require 'minitest/reporters'
+Minitest::Reporters.use!
+
+class ProblemTest < Minitest::Test
+  def test_sorted_names_array
+    assert_equal 28, 28.sum_of_proper_divisors
+    assert_equal false, 28.abundant?
+    assert_equal 16, 12.sum_of_proper_divisors
+    assert_equal true, 12.abundant?
+    assert_equal 1, 1.sum_of_proper_divisors
+  end
+end

--- a/no023/problem_test.rb
+++ b/no023/problem_test.rb
@@ -12,4 +12,9 @@ class ProblemTest < Minitest::Test
     assert_equal true, 12.abundant?
     assert_equal 1, 1.sum_of_proper_divisors
   end
+
+  def test_answer_method
+    sum = answer(1, 23)
+    assert_equal sum, answer(1, 24)
+  end
 end


### PR DESCRIPTION
問題文
---
A perfect number is a number for which the sum of its proper divisors is exactly equal to the number. For example, the sum of the proper divisors of 28 would be 1 + 2 + 4 + 7 + 14 = 28, which means that 28 is a perfect number.

A number n is called deficient if the sum of its proper divisors is less than n and it is called abundant if this sum exceeds n.

As 12 is the smallest abundant number, 1 + 2 + 3 + 4 + 6 = 16, the smallest number that can be written as the sum of two abundant numbers is 24. By mathematical analysis, it can be shown that all integers greater than 28123 can be written as the sum of two abundant numbers. However, this upper limit cannot be reduced any further by analysis even though it is known that the greatest number that cannot be expressed as the sum of two abundant numbers is less than this limit.

Find the sum of all the positive integers which cannot be written as the sum of two abundant numbers.

---

完全数とは, その数の真の約数の和がそれ自身と一致する数のことである. たとえば, 28の真の約数の和は, 1 + 2 + 4 + 7 + 14 = 28 であるので, 28は完全数である.

真の約数の和がその数よりも少ないものを不足数といい, 真の約数の和がその数よりも大きいものを過剰数と呼ぶ.

12は, 1 + 2 + 3 + 4 + 6 = 16 となるので, 最小の過剰数である. よって2つの過剰数の和で書ける最少の数は24である. 数学的な解析により, 28123より大きい任意の整数は2つの過剰数の和で書けることが知られている. 2つの過剰数の和で表せない最大の数がこの上限よりも小さいことは分かっているのだが, この上限を減らすことが出来ていない.

2つの過剰数の和で書き表せない正の整数の総和を求めよ.

その他
---